### PR TITLE
Added container name to the autoheal logs

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -25,9 +25,10 @@ if [ "$1" = 'autoheal' ] && [ -e ${DOCKER_SOCK} ]; then
     CONTAINERS=$(curl --no-buffer -s -XGET --unix-socket ${DOCKER_SOCK} http://localhost/containers/json | selector)
     for CONTAINER in $CONTAINERS; do
       HEALTH=$(curl --no-buffer -s -XGET --unix-socket ${DOCKER_SOCK} http://localhost/containers/${CONTAINER}/json | jq -r .State.Health.Status)
+      NAME=$(curl --no-buffer -s -XGET --unix-socket ${DOCKER_SOCK} http://localhost/containers/${CONTAINER}/json | jq -r .Name)
       if [ "unhealthy" = "$HEALTH" ]; then
         DATE=$(date +%d-%m-%Y" "%H:%M:%S)
-        echo "$DATE Container ${CONTAINER:0:12} found to be unhealthy. Restarting container ..."
+        echo "$DATE Container ${CONTAINER:0:12} found to be unhealthy. Restarting container $NAME ..."
         # Note: kill and stop didn't honor the restart policy
         #curl --no-buffer -s -XPOST --data '{"signal":"SIGKILL"}' --unix-socket ${DOCKER_SOCK} http://localhost/containers/${CONTAINER}/kill
         curl --no-buffer -s -XPOST --unix-socket ${DOCKER_SOCK} http://localhost/containers/${CONTAINER}/restart


### PR DESCRIPTION
It would be interesting to see the container name along with the container id in the autoheal logs.